### PR TITLE
!winrate, Add support for 'last 5 days' timespan

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ You're free to Woolooloo if you can pull it off, KEKW
 **Parameters:**   
 - `player` optionally specifies the comma separated profile ids of the default player(s) if query is empty. (If multiple, the matches of both accounts will be grouped before being evaluated)
 - `leaderboard` used to search the player. (Note: match isn't filtered for the particular leaderboard)
-- `query` can be empty, a rank `#1` or a player name. Additionally can be `vs abc` (default vs abs) and `abc vs def`. Supports a `last x hours/days/months` suffix to override t he `timespan` parameter.
+- `query` can be empty, a rank `#1` or a player name. Additionally can be `vs abc` (default vs abs) and `abc vs def`. Supports a `last x hours/days/months` suffix to override the `timespan` parameter.
 - `timespan` instead of detecting sessions, use the specified interval in hours. 
-- `gap` specifies the idle time in hours between games, defaults to 4h. Ignored when `timespan` is not empty.
+- `idletime` specifies the idle time in hours between games, defaults to 4h. Ignored when `timespan` is not empty.
 
 **Examples:**   
 - `!winrate` -> Liquid.DeMusliM played 4 games (3-0 | 100%) lasting 1 hour, 29 min ago

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ You're free to Woolooloo if you can pull it off, KEKW
 - `leaderboard` defaults to `rm_1v1`  
 - `query` can be empty, a rank `#1` or a player name.
 
-**Examples:**   
-- `!rank` -> "Liquid.DeMusliM" is rank #4 (D3, 1366 Elo), with 56 games (46-10 | 82.1%), on a 5-game win streak [last played 21 min ago]   
-- `!rank core` -> "coRe" is rank #12 (D2, 1281 Elo), with 81 games (55-26 | 67.9%), on a 6-game win streak [last played 1 day ago]   
-- `!rank #1` -> "Beastyqt" is rank #1 (C1, 1448 Elo), with 50 games (46-4 | 92%), on a 1-game losing streak [last played 19 hours ago]   
-- `!rank #51` -> "1puppypaw" is rank #51 (D1, 1174 Elo), with 14 games (12-2 | 85.7%), on a 2-game win streak [last played 7 min ago]
+**Examples:**
+- `!rank` -> Liquid.DeMusliM is rank 4 (D3, 1366 Elo), with 56 games (46-10 | 82.1%), on a 5-game win streak [last played 21 min ago]   
+- `!rank core` -> coRe is rank 12 (D2, 1281 Elo), with 81 games (55-26 | 67.9%), on a 6-game win streak [last played 1 day ago]   
+- `!rank #1` -> Beastyqt is rank 1 (C1, 1448 Elo), with 50 games (46-4 | 92%), on a 1-game losing streak [last played 19 hours ago]   
+- `!rank #51` -> 1puppypaw is rank 51 (D1, 1174 Elo), with 14 games (12-2 | 85.7%), on a 2-game win streak [last played 7 min ago]
 - `!rank alsdkfjasfldkj` -> Error: No player found
 - `!rank Serral` -> Serral is unranked, with 0 games
 
@@ -52,24 +52,17 @@ You're free to Woolooloo if you can pull it off, KEKW
 **Url:** `api/aoe4/winrate?query=$(querystring)&player=6943917,9087979&leaderboard=rm_1v1&format=nightbot`  
 **Description:** Returns the winrate of the player in the last playing session (a gap of 4h resets the session), can also be used to display the winrate between players in the same period. (Note: only the last 50 games are retrieved atm.)
 
-**TODO:** threshold of 4 hours should be configurable in the future, so ppl can have 'last 24 hours' or 'last week'
-
 **Parameters:**   
 - `player` optionally specifies the comma separated profile ids of the default player(s) if query is empty. (If multiple, the matches of both accounts will be grouped before being evaluated)
 - `leaderboard` used to search the player. (Note: match isn't filtered for the particular leaderboard)
-- `query` can be empty, a rank `#1` or a player name. Additionally can be `vs abc` (default vs abs) and `abc vs def`.
+- `query` can be empty, a rank `#1` or a player name. Additionally can be `vs abc` (default vs abs) and `abc vs def`. Supports a `last x hours/days/months` suffix to override t he `timespan` parameter.
+- `timespan` instead of detecting sessions, use the specified interval in hours. 
+- `gap` specifies the idle time in hours between games, defaults to 4h. Ignored when `timespan` is not empty.
 
 **Examples:**   
-- `!winrate` -> "Liquid.DeMusliM" played 4 games (3-0 | 100%) lasting 1 hour, 29 min ago
-- `!winrate vs HuT` -> "Liquid.DeMusliM" played 2 games (2-0 | 100%) lasting 49 min vs "HuT", 1 hour ago
-- `!winrate Don Artie` -> "Don Artie" played 7 games (6-1 | 85.7%) lasting 1 hour, 8 hours ago
-- `!winrate Don Artie vs Szalami` -> "Don Artie" played 3 games (3-0 | 100%) lasting 57 min vs "Szalami1", 8 hours ago
-- `!winrate Don Artie vs PilotElf` -> "Don Artie" played 2 games (1-1 | 50%) lasting 31 min vs "PilotElf8750880", 11 hours ago
-
-**TODO:** Cleanup format, remove double quotes. Omit (0-0 | 100%)
-
-## TODO
-
-- Add `threshold` as query parameter to `winrate` so users can specify what they want.
-- Cleanup `!match` output a bit for non 1v1. Atm it already simplifies for more than 2 teams. But 4v4 gets too crowded
-- Nice to have: Add `@qm_1v1` support in `!rank` like `!rank DeMuslim @qm_1v1`
+- `!winrate` -> Liquid.DeMusliM played 4 games (3-0 | 100%) lasting 1 hour, 29 min ago
+- `!winrate vs HuT` -> Liquid.DeMusliM played 2 games (2-0 | 100%) lasting 49 min vs HuT, 1 hour ago
+- `!winrate Don Artie` -> Don Artie played 7 games (6-1 | 85.7%) lasting 1 hour, 8 hours ago
+- `!winrate Don Artie vs Szalami` -> Don Artie played 3 games (3-0 | 100%) lasting 57 min vs Szalami1, 8 hours ago
+- `!winrate Don Artie vs PilotElf` -> Don Artie played 2 games (1-1 | 50%) lasting 31 min vs PilotElf8750880, 11 hours ago
+- `!winrate Beastyqt vs TheViper last 5 days` -> Beastyqt played 4 games (3-1 | 75%) lasting 1 hour vs GL.TheViper in the last 5 days, 2 days ago

--- a/aoe4/formatters.js
+++ b/aoe4/formatters.js
@@ -165,7 +165,7 @@ class NightbotDefaultFormatter {
 
     if (winrate.timespan) {
       msg += ` in the last ${formatDuration(winrate.timespan)}`;
-    } else if (winrate.gap) {
+    } else if (winrate.idletime) {
       msg += ` in their last session`;
     }
 

--- a/aoe4/formatters.js
+++ b/aoe4/formatters.js
@@ -156,7 +156,7 @@ class NightbotDefaultFormatter {
     }
 
     if (winrate.duration) {
-      msg +=  ` lasting ${formatDuration(winrate.duration)}`;
+      msg += ` totaling ${formatDuration(winrate.duration)}`;
     }
 
     if (winrate.opponent) {
@@ -164,7 +164,9 @@ class NightbotDefaultFormatter {
     }
 
     if (winrate.timespan) {
-      msg +=  ` in the last ${formatDuration(winrate.timespan)}`;
+      msg += ` in the last ${formatDuration(winrate.timespan)}`;
+    } else if (winrate.gap) {
+      msg += ` in their last session`;
     }
 
     if (winrate.pending_games == 1) {

--- a/aoe4/formatters.js
+++ b/aoe4/formatters.js
@@ -163,6 +163,10 @@ class NightbotDefaultFormatter {
       msg += ` vs ${winrate.opponent.name}`;
     }
 
+    if (winrate.timespan) {
+      msg +=  ` in the last ${formatDuration(winrate.timespan)}`;
+    }
+
     if (winrate.last_game_at) {
       msg += `, ${formatAge(winrate.last_game_at)} ago`;
     }

--- a/aoe4/formatters.js
+++ b/aoe4/formatters.js
@@ -167,8 +167,12 @@ class NightbotDefaultFormatter {
       msg +=  ` in the last ${formatDuration(winrate.timespan)}`;
     }
 
-    if (winrate.last_game_at) {
-      msg += `, ${formatAge(winrate.last_game_at)} ago`;
+    if (winrate.pending_games == 1) {
+      msg += ` [game ongoing since ${formatAge(winrate.pending_game_started_at)} ago]`;
+    } else if (winrate.pending_games > 1) {
+      msg += ` [${winrate.pending_games} games ongoing since ${formatAge(winrate.pending_game_started_at)} ago]`;
+    } else if (winrate.last_game_at) {
+      msg += ` [last played ${formatAge(winrate.last_game_at)} ago]`;
     }
 
     res.send(msg);

--- a/aoe4/handlers.js
+++ b/aoe4/handlers.js
@@ -44,6 +44,8 @@ async function getPlayerWinRate(player, opponent, gap, timespan) {
 
   var now = Date.now();
   var lastgame = games[0] ? Date.parse(games[0].started_at) : Date.now();
+  var pendingGames = 0;
+  var pendingGame = null;
 
   for (const game of games) {
 
@@ -60,8 +62,14 @@ async function getPlayerWinRate(player, opponent, gap, timespan) {
     lastgame = gametime;
 
     // Skip ongoing games in the calculation
-    if (!game.duration)
+    if (!game.duration) {
+      if (!pendingGame) {
+        pendingGame = game;
+      }
+      pendingGames += 1;
+
       continue;
+    }
 
     var playerState = null;
     var opponentState = null;
@@ -96,6 +104,11 @@ async function getPlayerWinRate(player, opponent, gap, timespan) {
     } else if (playerState.result == "loss") {
       stats.losses_count += 1;
     }
+  }
+
+  stats.pending_games = pendingGames;
+  if (pendingGame) {
+    stats.pending_game_started_at = pendingGame.started_at;
   }
 
   if (stats.losses_count) {

--- a/aoe4/handlers.js
+++ b/aoe4/handlers.js
@@ -63,13 +63,25 @@ async function getPlayerWinRate(player, opponent, gap, timespan) {
     if (!game.duration)
       continue;
 
-    var playerState = game.teams.flat().filter(p => playerProfileIds.includes(p.player.profile_id))[0]?.player;
-    var opponentState;
-    if (opponent) {
-      opponentState = game.teams.flat().filter(p => p.player.profile_id == opponent.profile_id)[0]?.player;
-      if (!opponentState) {
-        continue;
-      }
+    var playerState = null;
+    var opponentState = null;
+
+    for (const team of game.teams) {
+      const teamPlayer = team.filter(p => playerProfileIds.includes(p.player.profile_id))[0]?.player;
+      const teamOpponent = opponent ? team.filter(p => p.player.profile_id == opponent.profile_id)[0]?.player : null;
+
+      if (teamPlayer)
+        playerState = teamPlayer;
+      else if (teamOpponent) // Note this also filters out games where the player and opponent are in the same team
+        opponentState = teamOpponent;
+    }
+
+    if (!playerState) {
+      continue;
+    }
+
+    if (opponent && !opponentState) {
+      continue;
     }
 
     if (!stats.last_game_at) {

--- a/aoe4/handlers.js
+++ b/aoe4/handlers.js
@@ -191,7 +191,7 @@ async function handleAoe4Rank(req, res) {
 // format       Specifies the format of the output, defaults to json. 'nightbot' is a text output for twitch chat.
 async function handleAoe4WinRate(req, res) {
   var query = req.query.query || '';
-  const leaderboard = req.query.leaderboard || 'rm_1v1';
+  const leaderboard = req.query.leaderboard;
   const format = req.query.format;
   var timespan = req.query.timespan !== undefined ? parseInt(req.query.timespan) : null;
   const gap = req.query.gap !== undefined ? parseInt(req.query.gap) : 4;

--- a/aoe4/handlers.js
+++ b/aoe4/handlers.js
@@ -34,6 +34,7 @@ async function getPlayerWinRate(player, opponent, gap, timespan) {
     player:  Array.isArray(player) ? player[0] : player,
     opponent: opponent,
     timespan: timespan,
+    gap: gap,
     games_count: 0,
     wins_count: 0,
     losses_count: 0,

--- a/aoe4/handlers.js
+++ b/aoe4/handlers.js
@@ -18,12 +18,12 @@ function parseTimespan(number, suffix) {
   return null;
 }
 
-// gap is the session idle time, defaults to 4 * 3600 seconds. timespan overrides that and is an absolute interval in seconds.
-async function getPlayerWinRate(player, opponent, gap, timespan) {
+// idletime is the session idle time, defaults to 4 * 3600 seconds. timespan overrides that and is an absolute interval in seconds.
+async function getPlayerWinRate(player, opponent, idletime, timespan) {
   const playerProfileIds = Array.isArray(player) ? player.map(p => p.profile_id) : [ player.profile_id ];
 
-  if (gap === undefined) {
-    gap = 4 * 3600;
+  if (idletime === undefined) {
+    idletime = 4 * 3600;
   }
 
   // Get the games iterator, which will fetch new pages as needed and multiplex profiles.
@@ -34,7 +34,7 @@ async function getPlayerWinRate(player, opponent, gap, timespan) {
     player:  Array.isArray(player) ? player[0] : player,
     opponent: opponent,
     timespan: timespan,
-    gap: gap,
+    idletime: idletime,
     games_count: 0,
     wins_count: 0,
     losses_count: 0,
@@ -54,7 +54,7 @@ async function getPlayerWinRate(player, opponent, gap, timespan) {
     var gametime = Date.parse(game.started_at);
 
     if (!timespan) {
-      if (lastgame && (lastgame - gametime) > gap * 1000)
+      if (lastgame && (lastgame - gametime) > idletime * 1000)
         break;
     } else {
       if ((now - gametime) > timespan * 1000)
@@ -213,7 +213,7 @@ async function handleAoe4WinRate(req, res) {
   const leaderboard = req.query.leaderboard;
   const format = req.query.format;
   var timespan = req.query.timespan !== undefined ? parseInt(req.query.timespan) : null;
-  const gap = req.query.gap !== undefined ? parseInt(req.query.gap) : 4;
+  const idletime = req.query.idletime !== undefined ? parseInt(req.query.idletime) : 4;
 
   const formatter = getFormatter(format);
 
@@ -263,7 +263,7 @@ async function handleAoe4WinRate(req, res) {
   }
 
   if (player.length && player[0]) {
-    const winrate = await getPlayerWinRate(player, opponent, gap * 3600, timespan * 3600);
+    const winrate = await getPlayerWinRate(player, opponent, idletime * 3600, timespan * 3600);
     if (winrate) {
       winrate.player = player[0];
       if (opponent) winrate.opponent = opponent;


### PR DESCRIPTION
TODO:
- [x] Use paging on `players/x/games` api for longer timespans
- [ ] Wait for aoe4world devs to implement opponent filter in the api and use that api call where appropriate
- [ ] Agree on final formatting
- [x] How about 'idletime' instead of 'gap'?

Questions:
- [ ] Consider limiting `gap` to max 24 hours or something. Since it's a more intensive query.
- [ ] Consider limiting `timespan` to x months. aoe4world devs will likely implement a player vs player winrate endpoint at one point. Alleviating some performance concerns.

closes #3